### PR TITLE
fix: update color for completions

### DIFF
--- a/ports/wezterm/ferra.toml
+++ b/ports/wezterm/ferra.toml
@@ -11,7 +11,7 @@ ansi = [
 ]
 background = '#2b292d'
 brights = [
-    '#2b292d',
+    '#6f5d63',
     '#e06b75',
     '#9f9f7c',
     '#fff27a',


### PR DESCRIPTION
The color used for completions was the same as the background color. This has been updated to `bark` instead

![completion color](https://i.jeppe.ch/7jfVOmP9Ihmi.png)